### PR TITLE
Testy do Pull Requesta feature/access_logs

### DIFF
--- a/api/app/crud/access_logs.py
+++ b/api/app/crud/access_logs.py
@@ -143,6 +143,12 @@ class AccessLogsCRUD:
                     detail=f'Student {user_id} not found.',
                 )
 
+            if not student.class_id:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f'Student {user_id} is not assigned to any class.',
+                )
+
             lesson_instance = LessonInstancesCRUD.get_current_lesson_instance_for_class_or_teacher(
                 db=db,
                 class_id=student.class_id,
@@ -335,7 +341,7 @@ class AccessLogsCRUD:
         if not access_log:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
-                detail=f'Access log {access_log_id} not found. Or is outdated',
+                detail=f'Access log {access_log_id} not found',
             )
 
         if not(access_log.access_start_time <= approval_data.current_time and access_log.access_start_time >= ten_minutes_ago):

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -9,6 +9,7 @@ from app.oauth2 import create_access_token
 from app import models 
 from .fixtures.users import user_factory
 from .fixtures.school import school_admin_factory
+from .fixtures.classes import classes_factory
 
 SQLALCHEMY_DATABASE_URL = settings.test_database_url
 
@@ -77,7 +78,30 @@ def authorized_student_client(client, student_token):
     client.headers.update({
         "Authorization": f"Bearer {token}"
     })
-    return student, client 
+    return student, client
+
+@pytest.fixture
+def test_student_class4D(client, school_admin_factory, user_factory, classes_factory):
+    school, _, _ = school_admin_factory()
+    school_id = school.id
+    klass = classes_factory(school_id=school_id, class_name="4D")
+    student = user_factory(role="student", school_id=school_id, email="student4d@example.com", class_id=klass.id)
+    return student, klass
+
+@pytest.fixture
+def student_class_4D_token(test_student_class4D):
+    student, klass = test_student_class4D
+    return student, klass, create_access_token({"user_id": student.user.id, "role": student.user.role})
+
+@pytest.fixture
+def authorized_student_class4D_client(client, student_class_4D_token):
+    student, klass, token = student_class_4D_token
+    client.headers.clear()
+    client.headers.update({
+        "Authorization": f"Bearer {token}"
+    })
+    return student, klass, client
+
 
 @pytest.fixture 
 def test_teacher(client, school_admin_factory, user_factory):

--- a/api/tests/fixtures/access_logs.py
+++ b/api/tests/fixtures/access_logs.py
@@ -1,0 +1,22 @@
+import pytest
+from datetime import datetime
+from app.models import AccessLog
+from sqlalchemy.orm import Session
+
+@pytest.fixture
+def access_logs_factory(session: Session):
+    def create_access_log(
+        user_id: int,
+        room_id: int,
+        access_time: datetime
+    ):
+        access_log = AccessLog(
+            user_id=user_id,
+            room_id=room_id,
+            access_time=access_time
+        )
+        session.add(access_log)
+        session.commit()
+        session.refresh(access_log)
+        return access_log
+    return create_access_log

--- a/api/tests/test_access_logs.py
+++ b/api/tests/test_access_logs.py
@@ -1,0 +1,106 @@
+import pytest
+from .conftest import (authorized_admin_client,
+                       authorized_teacher_client,
+                       authorized_student_client,
+                        authorized_student_class4D_client
+                       )
+from .fixtures.lesson_instances import lesson_instance_factory
+from .fixtures.lesson_templates import lesson_template_factory
+from .fixtures.rooms import room_factory
+from .fixtures.school import school_admin_factory
+from .fixtures.users import user_factory
+from .fixtures.classes import classes_factory
+from datetime import datetime
+from datetime import datetime, timedelta
+from .fixtures.attendances import attendance_factory
+from .fixtures.access_logs import access_logs_factory
+
+
+# TESTS:
+# 1. request_access_log_student_granted_by_schedule
+def test_request_access_log_student_granted_by_schedule(
+        authorized_student_class4D_client,
+        session,
+        lesson_template_factory,
+        lesson_instance_factory,
+        room_factory,
+        user_factory,
+        classes_factory,
+):
+    student, klass, client = authorized_student_class4D_client
+    school_id = student.user.school_id
+    room = room_factory(school_id=school_id)
+    teacher = user_factory(school_id=school_id, role='teacher', email="teacher1@example.com")
+    template = lesson_template_factory(
+        school_id=school_id,
+        room_id=room.id,
+        teacher_id=teacher.id,
+        class_id=klass.id,
+        start_time="10:05",
+        end_time="10:50",
+        weekday=0
+    )
+
+
+    start_time = datetime(year=2025, month=5, day=15, hour=10, minute=5)
+    end_time = datetime(year=2025, month=5, day=15, hour=10, minute=50)
+
+    lesson_instance = lesson_instance_factory(
+        template_id=template.id,
+        class_id=klass.id,
+        room_id=room.id,
+        teacher_id=teacher.id,
+        subject="computer science",
+        start_time=start_time,
+        end_time=end_time,
+    )
+    payload = {
+        "user_id": student.user.id,
+        "room_id": room.id,
+        "access_time": start_time.isoformat()
+    }
+
+    res = client.post(f"/school/{school_id}/access-logs/request", json=payload)
+    data = res.json()
+    print(data)
+    assert res.status_code == 200
+# 2. request_access_log_student_not_assigned_to_any_class
+
+# 3. request_access_log_student_denied_by_schedule
+# 4. request_access_log_already_exists
+# 5. request_access_log_invalid_data
+# 6. request_access_log_provided_user_is_not_student
+
+# 7. get_all_denied_access_logs_for_teacher
+# 8. get_all_denied_access_logs_for_teacher_time_edge_case
+# 9. get_all_denied_access_logs_for_teacher_not_in_time_range
+# 10. get_all_denied_access_logs_for_teacher_not_having_lesson
+# 11. get_all_denied_access_logs_for_teacher_as_student
+
+# 12. approve_access_log_success
+# 13. deny_access_log_success
+# 14. review_access_log_invalid_status
+# 15. review_access_log_not_found_access_log
+# 16. review_access_log_outdated_access_log
+# 17. review_access_log_teacher_not_having_lesson
+
+# 18. open_door_as_teacher_success
+# 19. open_door_as_admin_success
+# 20. open_door_as_student
+# 21. close_door_as_teacher_success
+# 22. open_door_as_teacher_invalid_data_in
+
+# 23. get_all_access_logs_not_permitted
+# 24. get_all_access_logs_as_admin_success
+# 25. get_all_access_logs_as_admin_date_range
+# 26. get_all_access_logs_empty_list
+# 27. get_all_access_logs_paginated
+# 28. get_all_access_logs_paginated_for_specific_room_id
+
+# 29. get_attendance_after_successful_student_request_status_present
+# 30. get_attendance_after_successful_student_request_status_absent
+# 31. get_attendance_after_successful_student_request_status_late
+
+# here will be also tests for websockets for:
+#   - students request endpoint
+#   - teacher approval endpoint


### PR DESCRIPTION
## Dodanie testów jednostkowych do feature/access_logs

W tym pull requeście dodaję brakujące testy jednostkowe, które powinny były znaleźć się w poprzednim PR dotyczącym access logów (`feature/access_logs`, już zmergowanym).

Główne zmiany:

- Przygotowanie i wykorzystanie fixture’a imitującego zalogowanego ucznia przypisanego do klasy 4D, co pozwala testować przypadki zgodne z rzeczywistym scenariuszem działania systemu.
- Pokrycie przypadków związanych z endpointem `/access-logs/request`, m.in.:
  - prawidłowy request ucznia przypisanego do klasy i pasującego do planu lekcji,
  - odmowa dostępu dla ucznia nieprzypisanego do żadnej klasy,
  - odmowa dostępu na podstawie niezgodności z planem,
  - próba wysłania requestu przez użytkownika, który nie jest uczniem,
  - przypadek, gdy taki request już istnieje,
  - walidacja błędnych danych wejściowych.
- Przygotowanie kolejnych testów do endpointów review access logów (zatwierdzanie/odrzucanie), pobierania denied logs przez nauczyciela, oraz operacji otwierania drzwi przez różne role.
- Zaplanowane również testy integracyjne pod WebSockety: requesty ucznia oraz zatwierdzenia nauczyciela.

Ten PR ma na celu domknięcie test coverage’u dla funkcjonalności access logów i zabezpieczenie przed potencjalnymi błędami logicznymi, jak ten wykryty wcześniej — umożliwiający wysyłanie requestu przez ucznia nieprzypisanego do klasy.

---
PR powiązany z: `feature/access_logs` ✅
