### PR TITLE
Feature/mobile access logs

### DIFF
--- a/api/app/crud/access_logs.py
+++ b/api/app/crud/access_logs.py
@@ -497,3 +497,18 @@ class AccessLogsCRUD:
             "total_count": total_count,
             "access_logs": access_logs,
         }
+
+    @staticmethod
+    def get_access_log(
+            db: Session,
+            access_log_id: int,
+    ):
+        access_log = db.query(AccessLog).filter(
+            AccessLog.id == access_log_id,
+        ).first()
+        if not access_log:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f'Access log {access_log_id} not found.',
+            )
+        return access_log

--- a/api/app/routes/schools/access_logs.py
+++ b/api/app/routes/schools/access_logs.py
@@ -144,3 +144,22 @@ def get_all_access_logs(
         page=page,
         limit=limit,
     )
+@router.delete("/{access_log_id}", dependencies=[Depends(student_admin)])
+
+def delete_access_log(
+    school_id: int,
+    access_log_id: int,
+    db: Session = Depends(get_db),
+    school_checker: User = Depends(school_checker),
+    current_user: User = Depends(get_current_user),
+):
+    access_log = AccessLogsCRUD.get_access_log(
+        db=db,
+        access_log_id=access_log_id,
+    )
+    protect(user_id=access_log.user_id, permitted_roles=["admin"], current_user=current_user, db=db)
+
+    return AccessLogsCRUD.delete_access_log(
+        db=db,
+        access_log_id=access_log_id,
+    )

--- a/api/app/routes/schools/lesson_instances.py
+++ b/api/app/routes/schools/lesson_instances.py
@@ -1,4 +1,4 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends,HTTPException, status
 from app.database import get_db
 from ...crud.lesson_instance import LessonInstancesCRUD
 from typing import List
@@ -122,9 +122,15 @@ def get_current_lesson_instance_for_class(
         db: Session = Depends(get_db),
         school_checker: User = Depends(school_checker)
 ):
-    return LessonInstancesCRUD.get_current_lesson_instance_for_class_or_teacher(
+    lesson_instance =  LessonInstancesCRUD.get_current_lesson_instance_for_class_or_teacher(
         db=db,
         class_id=class_id,
         school_id=school_id,
         current_time=current_time_obj.current_time
     )
+    if not lesson_instance:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Currently there is no lesson for given {'class' if class_id else 'teacher'}"
+        )
+    return lesson_instance

--- a/api/app/routes/schools/rooms.py
+++ b/api/app/routes/schools/rooms.py
@@ -26,6 +26,19 @@ def create_room(
         room_data=room_data
     )
 
+@router.get("/raw_rooms", response_model=room.PaginatedRoomRaw)
+def get_all_rooms(
+    school_id: int,
+    db: Session = Depends(get_db),
+    school_checker: User = Depends(school_checker),
+):
+    return RoomsCRUD.get_all_rooms(
+        db=db,
+        school_id=school_id,
+        query=None,
+        page=1,
+        limit=999
+    )
 @router.get("/", response_model=room.PaginatedRooms, dependencies=[Depends(admin_only)])
 def get_all_rooms(
     school_id: int,

--- a/api/app/schemas/room.py
+++ b/api/app/schemas/room.py
@@ -20,3 +20,12 @@ class PaginatedRooms(BaseModel):
     total_count: int 
     has_next_page: bool 
     rooms: List[RoomOut]
+
+class RoomRawOut(BaseModel):
+    id: int
+    room_name: str
+
+class PaginatedRoomRaw(BaseModel):
+    total_count: int
+    has_next_page: bool
+    rooms: List[RoomRawOut]

--- a/mobile/app/(root)/(student)/door_requests.tsx
+++ b/mobile/app/(root)/(student)/door_requests.tsx
@@ -1,9 +1,72 @@
-import {Text, View} from "react-native";
+import {SafeAreaView, Text, View} from "react-native";
+import {useCurrentLessonInstance} from "@/hooks/schedule";
+import {useAuth} from "@/context/AuthContext";
+import {useStudent} from "@/hooks/students";
+import Loader from "@/components/Loader";
+import ErrorMessage from "@/components/ErrorMessage";
+import StudentDoorRequest from "@/components/access_logs/StudentDoorRequest";
 const Index = () => {
+    const {user, token} = useAuth();
+
+    const {
+        data: student,
+        isLoading: studentIsLoading,
+        isError: studentIsError,
+        error: studentError,
+        refetch: refetchStudent
+    } = useStudent(
+        `school/${user?.school_id}/students`,
+        user?.id,
+        token || ""
+    )
+
+    const {
+        data: currentLesson,
+        isLoading: lessonIsLoading,
+        isError: lessonIsError,
+        error: lessonError,
+        refetch: refetchCurrentLesson
+    } = useCurrentLessonInstance(
+        `school/${user?.school_id}/lesson_instances`,
+        student?.class_.id,
+        token || ""
+    )
+
+    let content = <Loader/>;
+
+    if (studentIsLoading || lessonIsLoading) content = <Loader/>
+
+    if (studentIsError) content = (
+      <ErrorMessage
+          title={"Failed to load student"}
+          message={studentError?.message || "Please try again later"}
+          retryLabel={"Retry"}
+          onRetry={() => refetchStudent()}
+      />
+    )
+    if (lessonError) content = (
+      <ErrorMessage
+          title={"Something went wrong"}
+          message={lessonError?.message || "Failed to load lesson instances"}
+          retryLabel={"Retry"}
+          onRetry={() => refetchCurrentLesson()}
+      />
+    )
+    if (!studentIsLoading && !lessonIsLoading && !studentIsError && !lessonIsError && currentLesson && user?.id) content = (
+     <StudentDoorRequest userId={user?.id} lesson={currentLesson} />
+    )
+    if (!currentLesson) content = <View className="h-[70%] w-full flex items-center justify-center"><Text className="text-red-200 text-2xl font-light">Aktualnie nie masz żadnej lekcji</Text></View>
+    console.log(currentLesson);
     return (
-        <View className="flex items-center justify-center">
-            <Text>door_requests</Text>
-        </View>
+        <SafeAreaView className="flex-1 bg-black py-0">
+            <View className="flex flex-row justify-between px-5 py-3 pt-12 bg-background">
+                <Text className="text-2xl text-center py-2 text-white">Classrooms</Text>
+            </View>
+            <View className="h-full flex items-center py-10">
+                {currentLesson && <Text className="text-text font-semibold text-2xl py-5">Your current lesson</Text>}
+            {content}
+            </View>
+        </SafeAreaView>
     );
 };
 

--- a/mobile/components/access_logs/StudentDoorRequest.tsx
+++ b/mobile/components/access_logs/StudentDoorRequest.tsx
@@ -1,0 +1,185 @@
+import React, {useEffect, useState} from "react";
+import {
+  Modal,
+  TextInput,
+  TouchableOpacity,
+  View,
+  Text,
+} from "react-native";
+import { format } from "date-fns";
+import {ILessonInstance} from "@/types/schedule";
+import {useSendAccessLogRequest} from "@/hooks/access_logs";
+import {useAuth} from "@/context/AuthContext";
+import {Toast} from "toastify-react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {IAccessLog} from "@/types/AccessLogs";
+
+interface StudentDoorRequestProps {
+  lesson: ILessonInstance;
+  userId: number;
+}
+
+const StudentDoorRequest = ({
+    lesson,
+    userId
+}: StudentDoorRequestProps) => {
+    const {user, token} = useAuth();
+    const [existingAccessLog, setExistingAccessLog] = useState<IAccessLog | null>(null);
+    const sendAccessLogMutation = useSendAccessLogRequest(
+        `school/${user?.school_id}/access-logs`,
+        token || ""
+    )
+    useEffect(() => {
+        const getExistingAccessLog = async () => {
+            const existingAccessLog = await AsyncStorage.getItem(`${lesson.room.id}`)
+            console.log(existingAccessLog)
+            if (existingAccessLog)
+                setExistingAccessLog(JSON.parse(existingAccessLog))
+            else setExistingAccessLog(null)
+        }
+        getExistingAccessLog();
+    }, [sendAccessLogMutation.isPending]);
+
+
+    const [grantedModalVisible, setGrantedModalVisible] = useState(false);
+    const [deniedModalVisible, setDeniedModalVisible] = useState(false);
+    const [modalVisible, setModalVisible] = useState(false);
+    const [accessCode, setAccessCode] = useState("");
+
+
+    const handleEnter = () => {
+        setModalVisible(false);
+        sendAccessLogMutation.mutate({
+            user_id: userId,
+            room_id: lesson.room.id,
+            access_code: accessCode
+        }, {
+            onSuccess: (data) => {
+                if (data.access_status === "granted") {
+                    setGrantedModalVisible(true);
+                } else {
+                    setDeniedModalVisible(true);
+                }
+            },
+
+            onError: (err) => {
+                Toast.error(err.message || "Failed to send request")
+            }
+        })
+        setAccessCode("");
+    };
+    return (
+        <View className="p-5 w-[270px] bg-background rounded-2xl shadow-xl my-10">
+            <View className="flex flex-row py-1 px-3 gap-5 items-center">
+                <Text className="text-white font-semibold mb-1 text-2xl">{lesson.subject}</Text>
+                <Text className="text-subtext text-xl">{lesson.room.room_name}</Text>
+            </View>
+
+          <Text className="text-subtext text-lg mb-4 px-3">
+            {format(new Date(lesson.start_time), "HH:mm")} - {format(new Date(lesson.end_time), "HH:mm")}
+          </Text>
+
+          <TouchableOpacity
+            className="my-2 bg-primary py-3 px-4 rounded-2xl"
+            onPress={() => setModalVisible(true)}
+          >
+            <Text className="text-white text-center font-semibold text-2xl">{
+                              existingAccessLog && !existingAccessLog?.access_end_time ? (
+                                  "Leave"
+                              ) : (
+                                  "Enter"
+                              )
+                          } classroom</Text>
+          </TouchableOpacity>
+
+          {/* Modal */}
+          <Modal
+            visible={modalVisible}
+            animationType="slide"
+            transparent
+            onRequestClose={() => setModalVisible(false)}
+          >
+            <View className="flex-1 justify-center items-center bg-black/75">
+              <View className="bg-surface p-6 rounded-2xl w-4/5 shadow-lg">
+                <Text className="text-white text-2xl mb-4 text-center font-medium">
+                  Enter PIN Code
+                </Text>
+                <TextInput
+                  value={accessCode}
+                  onChangeText={setAccessCode}
+                  keyboardType="numeric"
+                  maxLength={4}
+                  placeholder="Enter PIN"
+                  placeholderTextColor="#7AC8F9"
+                  className="bg-background text-white p-3 rounded-xl mb-4 text-center text-xl my-1"
+                />
+                <TouchableOpacity
+                  onPress={handleEnter}
+                  className="bg-green-500 py-3 mt-4 mb-2 rounded-xl"
+                >
+                  <Text className="text-white text-xl text-center font-semibold">{
+                              existingAccessLog && !existingAccessLog?.access_end_time ? (
+                                  "Leave"
+                              ) : (
+                                  "Enter"
+                              )
+                          }</Text>
+                </TouchableOpacity>
+              </View>
+            </View>
+          </Modal>
+
+            <Modal
+                  visible={grantedModalVisible}
+                  transparent
+                  animationType="fade"
+                  onRequestClose={() => setGrantedModalVisible(false)}
+                >
+                  <View className="flex-1 justify-center items-center bg-black/75">
+                    <View className="bg-surface p-6 rounded-2xl w-4/5 shadow-lg">
+                      <Text className="text-green-400 text-xl font-semibold text-center mb-4">
+                          {
+                              existingAccessLog && !existingAccessLog?.access_end_time ? (
+                                  "Access granted. You may enter the classroom."
+                              ) : (
+                                  "You can leave the classroom."
+                              )
+                          }
+
+                      </Text>
+                      <TouchableOpacity
+                        onPress={() => setGrantedModalVisible(false)}
+                        className="bg-primary py-3 mt-2 rounded-xl"
+                      >
+                        <Text className="text-white text-center font-medium">OK</Text>
+                      </TouchableOpacity>
+                    </View>
+                  </View>
+                </Modal>
+
+                {/* Access Denied Modal */}
+                <Modal
+                  visible={deniedModalVisible}
+                  transparent
+                  animationType="fade"
+                  onRequestClose={() => setDeniedModalVisible(false)}
+                >
+                  <View className="flex-1 justify-center items-center bg-black/75">
+                    <View className="bg-surface p-6 rounded-2xl w-4/5 shadow-lg">
+                      <Text className="text-red-400 text-xl font-semibold text-center mb-4">
+                        Access denied. You have no lesson in this room. Please wait for teacher approval.
+                      </Text>
+                      <TouchableOpacity
+                        onPress={() => setDeniedModalVisible(false)}
+                        className="bg-primary py-3 mt-2 rounded-xl"
+                      >
+                        <Text className="text-white text-center font-medium">OK</Text>
+                      </TouchableOpacity>
+                    </View>
+                  </View>
+                </Modal>
+        </View>
+    );
+};
+
+export default StudentDoorRequest;

--- a/mobile/components/access_logs/StudentDoorRequest.tsx
+++ b/mobile/components/access_logs/StudentDoorRequest.tsx
@@ -17,14 +17,17 @@ import {IAccessLog} from "@/types/AccessLogs";
 interface StudentDoorRequestProps {
   lesson: ILessonInstance;
   userId: number;
+  setExistingAccessLog: (data: IAccessLog | null) => void;
+  existingAccessLog: IAccessLog | null;
 }
 
 const StudentDoorRequest = ({
     lesson,
-    userId
+    userId,
+    setExistingAccessLog,
+    existingAccessLog,
 }: StudentDoorRequestProps) => {
     const {user, token} = useAuth();
-    const [existingAccessLog, setExistingAccessLog] = useState<IAccessLog | null>(null);
     const sendAccessLogMutation = useSendAccessLogRequest(
         `school/${user?.school_id}/access-logs`,
         token || ""
@@ -69,7 +72,7 @@ const StudentDoorRequest = ({
         setAccessCode("");
     };
     return (
-        <View className="p-5 w-[270px] bg-background rounded-2xl shadow-xl my-10">
+        <View className="p-5 w-[270px] bg-background rounded-2xl shadow-xl my-3 mb-8">
             <View className="flex flex-row py-1 px-3 gap-5 items-center">
                 <Text className="text-white font-semibold mb-1 text-2xl">{lesson.subject}</Text>
                 <Text className="text-subtext text-xl">{lesson.room.room_name}</Text>

--- a/mobile/components/access_logs/StudentOtherRoomsRequest.tsx
+++ b/mobile/components/access_logs/StudentOtherRoomsRequest.tsx
@@ -1,0 +1,211 @@
+import React, {useEffect, useState} from "react";
+import {
+  Modal,
+  TextInput,
+  TouchableOpacity,
+  View,
+  Text,
+} from "react-native";
+import { format } from "date-fns";
+import {ILessonInstance} from "@/types/schedule";
+import {useDeleteAccessLogRequest, useSendAccessLogRequest} from "@/hooks/access_logs";
+import {useAuth} from "@/context/AuthContext";
+import {Toast} from "toastify-react-native";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {IAccessLog} from "@/types/AccessLogs";
+import {useRooms} from "@/hooks/rooms";
+import {IRoomRaw} from "@/types/Room";
+
+interface StudentDoorRequestProps {
+    userId: number;
+    rooms: IRoomRaw[];
+    setExistingDeniedAccessLog: (data: IAccessLog | null) => void;
+    existingDeniedAccessLog: IAccessLog | null;
+    setExistingApprovedAccessLog: (data: IAccessLog | null) => void;
+    existingApprovedAccessLog: IAccessLog | null;
+}
+
+const StudentDoorRequest = ({
+    userId,
+    rooms,
+    setExistingDeniedAccessLog,
+    existingDeniedAccessLog,
+    existingApprovedAccessLog,
+    setExistingApprovedAccessLog
+}: StudentDoorRequestProps) => {
+    const {user, token} = useAuth();
+    const [selectedRoom, setSelectedRoom] = useState<IRoomRaw | null>(null);
+    const sendAccessLogMutation = useSendAccessLogRequest(
+        `school/${user?.school_id}/access-logs`,
+        token || ""
+    )
+    const deleteAccessLogMutation = useDeleteAccessLogRequest(
+        `school/${user?.school_id}/access-logs`,
+        token || "",
+        existingDeniedAccessLog?.id,
+    )
+
+    // zrobić useEffect który jeżeli znajdzie jakikolwiek access log
+    // o statusie denied nie pozwoli wysłać kolejnego access requestu
+    // (czyli nie wyświetli się StudenrDoorRequest w komponencie door_request)
+    // chyba że użytkownik usunie swoj request
+
+    // jeżeli access log zostanie potwierdzony przez nauczyciela
+    // zostanie usuniety denied-${room.id}
+    // i zostanie dodany approved-${room.id}
+
+    const [modalVisible, setModalVisible] = useState(false);
+    const [accessCode, setAccessCode] = useState("");
+
+    const handleSelectRoom = (room_name: string) => {
+        setSelectedRoom(rooms.find((room) => room.room_name === room_name) || null)
+    }
+
+    useEffect(() => {
+        const getExistingAccessLog = async () => {
+            const existingAccessLog = await AsyncStorage.getItem(`denied`)
+            if (existingAccessLog)
+                setExistingDeniedAccessLog(JSON.parse(existingAccessLog))
+            else setExistingDeniedAccessLog(null)
+        }
+        getExistingAccessLog();
+    }, [sendAccessLogMutation.isPending, deleteAccessLogMutation.isPending]);
+
+    const handleEnter = () => {
+        if (!selectedRoom) return
+        setModalVisible(false);
+        sendAccessLogMutation.mutate({
+            user_id: userId,
+            room_id: selectedRoom?.id,
+            access_code: accessCode
+        }, {
+            onSuccess: (data) => {
+                // if (data.access_status === "granted") {
+                //     setGrantedModalVisible(true);
+                // } else {
+                //     setDeniedModalVisible(true);
+                // }
+            },
+
+            onError: (err) => {
+                Toast.error(err.message || "Failed to send request")
+            }
+        })
+        setAccessCode("");
+        setSelectedRoom(null);
+    };
+
+    const handleDelete = () => {
+        deleteAccessLogMutation.mutate(null,
+            {
+                onSuccess: (data) => {
+                    Toast.success("Successfully deleted");
+                },
+                onError: (err) => {
+                    Toast.error(err.message || "Failed to send request");
+                }
+            })
+    }
+    if (existingDeniedAccessLog) {
+        return (
+            <View className="py-5 px-5 w-[80%]">
+                <Text className="text-subtext text-2xl py-3 text-center leading-10">Your access request is waiting for approval</Text>
+                <TouchableOpacity
+                className="my-2 bg-red-500 py-3 px-4 rounded-2xl"
+                onPress={handleDelete}
+            >
+                <Text className="text-white text-center font-semibold text-2xl">Delete request</Text>
+            </TouchableOpacity>
+            </View>
+        )
+    }
+    return (
+        <View className="p-5 w-[270px] bg-surface rounded-2xl shadow-xl my-3">
+          <Text className="text-white text-xl mb-4 text-center font-medium">
+                  Enter Room data
+                </Text>
+                <TextInput
+                  value={selectedRoom?.room_name}
+                  onChangeText={handleSelectRoom}
+                  placeholder="Enter room"
+                  placeholderTextColor="#7AC8F9"
+                  className="bg-background text-white p-3 rounded-xl mb-4 text-center text-lg my-1"
+                />
+                <TextInput
+                  value={accessCode}
+                  onChangeText={setAccessCode}
+                  keyboardType="numeric"
+                  maxLength={4}
+                  placeholder="Enter PIN"
+                  placeholderTextColor="#7AC8F9"
+                  className="bg-background text-white p-3 rounded-xl mb-4 text-center text-lg my-1"
+                />
+                <TouchableOpacity
+                  onPress={handleEnter}
+                  className="bg-green-500 py-3 mt-4 mb-2 rounded-xl"
+                >
+                  <Text className="text-white text-xl text-center font-semibold">{
+                              existingApprovedAccessLog && !existingApprovedAccessLog?.access_end_time ? (
+                                  "Leave"
+                              ) : (
+                                  "Request for entry"
+                              )
+                          }</Text>
+                </TouchableOpacity>
+          {/* Modal */}
+
+
+            {/*<Modal*/}
+            {/*      visible={grantedModalVisible}*/}
+            {/*      transparent*/}
+            {/*      animationType="fade"*/}
+            {/*      onRequestClose={() => setGrantedModalVisible(false)}*/}
+            {/*    >*/}
+            {/*      <View className="flex-1 justify-center items-center bg-black/75">*/}
+            {/*        <View className="bg-surface p-6 rounded-2xl w-4/5 shadow-lg">*/}
+            {/*          <Text className="text-green-400 text-xl font-semibold text-center mb-4">*/}
+            {/*              {*/}
+            {/*                  existingAccessLog && !existingAccessLog?.access_end_time ? (*/}
+            {/*                      "Access granted. You may enter the classroom."*/}
+            {/*                  ) : (*/}
+            {/*                      "You can leave the classroom."*/}
+            {/*                  )*/}
+            {/*              }*/}
+
+            {/*          </Text>*/}
+            {/*          <TouchableOpacity*/}
+            {/*            onPress={() => setGrantedModalVisible(false)}*/}
+            {/*            className="bg-primary py-3 mt-2 rounded-xl"*/}
+            {/*          >*/}
+            {/*            <Text className="text-white text-center font-medium">OK</Text>*/}
+            {/*          </TouchableOpacity>*/}
+            {/*        </View>*/}
+            {/*      </View>*/}
+            {/*    </Modal>*/}
+
+            {/*    /!* Access Denied Modal *!/*/}
+            {/*    <Modal*/}
+            {/*      visible={deniedModalVisible}*/}
+            {/*      transparent*/}
+            {/*      animationType="fade"*/}
+            {/*      onRequestClose={() => setDeniedModalVisible(false)}*/}
+            {/*    >*/}
+            {/*      <View className="flex-1 justify-center items-center bg-black/75">*/}
+            {/*        <View className="bg-surface p-6 rounded-2xl w-4/5 shadow-lg">*/}
+            {/*          <Text className="text-red-400 text-xl font-semibold text-center mb-4">*/}
+            {/*            Access denied. You have no lesson in this room. Please wait for teacher approval.*/}
+            {/*          </Text>*/}
+            {/*          <TouchableOpacity*/}
+            {/*            onPress={() => setDeniedModalVisible(false)}*/}
+            {/*            className="bg-primary py-3 mt-2 rounded-xl"*/}
+            {/*          >*/}
+            {/*            <Text className="text-white text-center font-medium">OK</Text>*/}
+            {/*          </TouchableOpacity>*/}
+            {/*        </View>*/}
+            {/*      </View>*/}
+            {/*    </Modal>*/}
+        </View>
+    );
+};
+
+export default StudentDoorRequest;

--- a/mobile/hooks/access_logs.ts
+++ b/mobile/hooks/access_logs.ts
@@ -1,0 +1,33 @@
+import {useMutation, useQuery, useQueryClient} from "@tanstack/react-query";
+import {apiUrl} from "@/constants/constants";
+import {IAccessLog, IAccessLogRequestIn} from "@/types/AccessLogs";
+import {postFethcer} from "@/utils/fetcher";
+import {ILessonInstance} from "@/types/schedule";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+
+export function useSendAccessLogRequest(
+    endpoint: string,
+    token?: string,
+) {
+    const date = new Date()
+    const url = `${apiUrl}${endpoint}/request`;
+    const queryClient = useQueryClient();
+    return useMutation({
+        mutationFn: (data: IAccessLogRequestIn) =>
+            postFethcer<IAccessLog>(url, {
+                ...data,
+                // current_time: date.toISOString(),
+                access_time: "2025-06-16T15:00:21.681559"
+            }, token),
+        onSuccess: async (data) => {
+            if (data.access_status === "granted") {
+                if (data.access_end_time) {
+                    await AsyncStorage.removeItem(`${data.room.id}`)
+                } else {
+                    await AsyncStorage.setItem(`${data.room.id}`, JSON.stringify(data))
+                }
+            }
+            queryClient.invalidateQueries(["access-logs"])
+        }
+    })
+}

--- a/mobile/hooks/access_logs.ts
+++ b/mobile/hooks/access_logs.ts
@@ -1,7 +1,7 @@
 import {useMutation, useQuery, useQueryClient} from "@tanstack/react-query";
 import {apiUrl} from "@/constants/constants";
 import {IAccessLog, IAccessLogRequestIn} from "@/types/AccessLogs";
-import {postFethcer} from "@/utils/fetcher";
+import {deleteFetcher, postFethcer} from "@/utils/fetcher";
 import {ILessonInstance} from "@/types/schedule";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
@@ -17,7 +17,8 @@ export function useSendAccessLogRequest(
             postFethcer<IAccessLog>(url, {
                 ...data,
                 // current_time: date.toISOString(),
-                access_time: "2025-06-16T15:00:21.681559"
+                // access_time: "2025-06-16T15:00:21.681559"
+                access_time: "2025-06-16T09:14:21.681559"
             }, token),
         onSuccess: async (data) => {
             if (data.access_status === "granted") {
@@ -27,7 +28,30 @@ export function useSendAccessLogRequest(
                     await AsyncStorage.setItem(`${data.room.id}`, JSON.stringify(data))
                 }
             }
+            if (data.access_status === "denied") {
+                if(data.access_end_time) {
+                    await AsyncStorage.removeItem(`denied`)
+                } else {
+                    await AsyncStorage.setItem(`denied`, JSON.stringify(data))
+                }
+            }
             queryClient.invalidateQueries(["access-logs"])
+        }
+    })
+}
+
+export function useDeleteAccessLogRequest(
+    endpoint: string,
+    token?: string,
+    accessRequestId?: number
+) {
+    const queryClient = useQueryClient();
+    const url = `${apiUrl}${endpoint}/${accessRequestId}`;
+    return useMutation({
+        mutationFn: (data: null) => deleteFetcher(url, token),
+        onSuccess: async (data) => {
+            queryClient.invalidateQueries()
+            await AsyncStorage.removeItem("denied")
         }
     })
 }

--- a/mobile/hooks/rooms.ts
+++ b/mobile/hooks/rooms.ts
@@ -1,0 +1,23 @@
+import {useQuery} from "@tanstack/react-query";
+import {IRoomRaw} from "@/types/Room";
+import {fetcher} from "@/utils/fetcher";
+import {apiUrl} from "@/constants/constants";
+
+interface PaginatedRoomsResponse {
+    total_count: number;
+    has_next_page: boolean;
+    rooms: IRoomRaw[];
+}
+
+export function useRooms(
+    endpoint: string,
+    token?: string
+) {
+    return useQuery<PaginatedRoomsResponse>({
+        queryKey: ["rooms_raw"],
+        queryFn: () => fetcher<PaginatedRoomsResponse>(
+            `${apiUrl}${endpoint}/raw_rooms`,
+            token
+        )
+    })
+}

--- a/mobile/hooks/schedule.ts
+++ b/mobile/hooks/schedule.ts
@@ -1,7 +1,7 @@
 import {apiUrl} from "@/constants/constants";
 import {ILessonInstance} from "@/types/schedule";
 import {useQuery} from "@tanstack/react-query";
-import {fetcher} from "@/utils/fetcher";
+import {fetcher, postFethcer} from "@/utils/fetcher";
 
 export function useLessonInstance(
     endpoint: string,
@@ -16,5 +16,24 @@ export function useLessonInstance(
         queryKey: ["lessonInstances", id, dateStr],
         queryFn: () => fetcher<ILessonInstance[]>(url, token),
         enabled: !!id
+    })
+}
+
+export function useCurrentLessonInstance(
+    endpoint: string,
+    classId?: number,
+    token?: string,
+) {
+    const date = new Date()
+    const minutesRoundedToTen = Math.round(date.getMinutes() / 6);
+    const dateKey = `${date.getDate()}-${date.getHours()}-${minutesRoundedToTen}`
+    const url = `${apiUrl}${endpoint}/classes/${classId}/current`;
+    return useQuery<ILessonInstance>({
+        queryKey: ["lessonInstance", classId, dateKey],
+        queryFn: () => postFethcer<ILessonInstance>(url, {
+            // current_time: date.toISOString(),
+            current_time: "2025-06-16T15:00:21.681559"
+        }, token ),
+
     })
 }

--- a/mobile/types/AccessLogs.ts
+++ b/mobile/types/AccessLogs.ts
@@ -1,0 +1,43 @@
+import {IUser} from "@/types/User";
+import {IRoom} from "@/types/Room";
+
+export type accessStatus = "denied" | "granted";
+
+export interface IAccessLogRaw {
+    id: number;
+    user_id: number;
+    room_id: number;
+    access_start_time: Date;
+    access_end_time: Date;
+    reason: string;
+    access_status: accessStatus;
+    created_at: Date;
+}
+
+export interface IAccessLog {
+    id: number;
+    user: IUser
+    room: IRoom;
+    access_start_time: Date;
+    access_end_time: Date;
+    reason: string;
+    access_status: accessStatus;
+    created_at: Date;
+}
+
+export interface IAccessLogIn {
+    user_id: number;
+    room_id: number;
+    access_time: Date;
+}
+export interface IAccessLogRequestIn {
+    user_id: number;
+    room_id: number;
+    access_code: string;
+}
+
+export interface IAccessLogApproval {
+    status: accessStatus;
+    user_id: number | null;
+    current_time: string;
+}

--- a/mobile/types/Room.ts
+++ b/mobile/types/Room.ts
@@ -6,3 +6,7 @@ export interface IRoom {
     updated_at: Date;
     school_id: number;
 }
+export interface IRoomRaw {
+    id: number;
+    room_name: string;
+}


### PR DESCRIPTION
# 🚀 Dodanie możliwości wysyłania requestów do sal lekcyjnych, w których uczeń nie ma lekcji

## Opis zmian

W tym PR dodano funkcjonalność umożliwiającą uczniowi wysyłanie requestów o dostęp do sal lekcyjnych, w których **nie ma zaplanowanych lekcji**. Zmiany obejmują również dodanie logiki ograniczającej możliwość wysyłania wielu requestów oraz poprawki w interfejsie użytkownika.

## Szczegóły implementacji

- ✅ Dodano możliwość wysyłania requestów do sal lekcyjnych, w których uczeń **nie ma lekcji**.
- ✅ Jeżeli uczeń **wysłał request** do sali lekcyjnej, w której **ma lekcje i jest potwierdzony**, **nie może wysłać innego requesta**. Interfejs nie pokazuje tej opcji.
- ✅ Jeżeli uczeń **wysłał request** do sali, w której **nie ma lekcji**, również **nie może wysłać kolejnego requesta** — pojawia się jedynie komunikat z informacją, że należy poczekać na potwierdzenie lub usunąć istniejący request.
- ✅ Zaimplementowano funkcjonalność do obsługi requestów do sal, w których uczeń **ma planowo lekcje** 

## Co dalej?

Poniżej znajduje się lista zadań zaplanowanych na przyszłość:
- [ ] 🔁 Dodać websocket po stronie ucznia do odbierania **odrzucenia lub potwierdzenia requesta** w czasie rzeczywistym.
- [ ] 👨‍🏫 Stworzyć **widok nauczyciela** w aplikacji mobilnej z możliwością **akceptacji lub odrzucenia** requestów do sali lekcyjnej.
- [ ] 🌐 Dodać websocket po stronie nauczyciela do odbierania requestów w czasie rzeczywistym, w sali, w której aktualnie prowadzi lekcje.

